### PR TITLE
Изменена обработка вхождений в SwiftUI

### DIFF
--- a/Sources/SUR/Parsers/SwiftVisitors/FuncCallVisitor.swift
+++ b/Sources/SUR/Parsers/SwiftVisitors/FuncCallVisitor.swift
@@ -66,6 +66,10 @@ class FuncCallVisitor: SyntaxVisitor {
                 return
             }
             
+            if (tuple.label?.text != nil) {
+                return
+            }
+            
             if let comment = findComment(tuple) {
                 register(.regexp(comment))
                 return
@@ -148,6 +152,10 @@ class FuncCallVisitor: SyntaxVisitor {
     override func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
         name = node.identifier.text
         
+        return .skipChildren
+    }
+    
+    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 }

--- a/SwiftUnusedResources.podspec
+++ b/SwiftUnusedResources.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
   spec.name                         = 'SwiftUnusedResources'
   spec.summary                      = 'SwiftUnusedResources'
   spec.homepage                     = 'https://github.com/mugabe/SwiftUnusedResources'
-  spec.version                      = '0.0.4'
+  spec.version                      = '0.0.5'
   spec.license                      = 'MIT'
   spec.authors                      = { 'mugabe' => 'kk@wachanga.com' }
   spec.preserve_paths               = 'sur', 'lib_InternalSwiftSyntaxParser.dylib'


### PR DESCRIPTION
- Добавлена проверка содержимого `Image`, обработка начнется, только если аргумент функции не содержит `label`, чтобы опустить проверку функций, которые не создают `Image` из ассетов.
- Добавлен пропуск обработки `Image` вместе с примененными модификаторами, так как в этом случае он будет обработан некорректно, при этом отдельно будет запущена проверка без модификаторов